### PR TITLE
Support for Configurable Mongo Indexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
+/fhir-server
 *.o
 *.a
 *.so

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Before you can run the FHIR server, you must install its dependencies via `go ge
 
 ```
 $ cd $GOPATH/src/github.com/mitre/fhir-server
+$ go get
 $ go build
 ```
 

--- a/config/indexes.conf
+++ b/config/indexes.conf
@@ -1,0 +1,1023 @@
+# GoFHIR Indexes Configuration
+#
+# GoFHIR runs db.collection.ensureIndex() on startup for each of the indexes enabled in this file.
+# We use mongo's default naming convention for our indexes, see:
+# https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/#options-for-all-index-types
+#
+# The indexes in this file are grouped by resource and organized into two categories:
+# 1. Required - to perform queries at scale GoFHIR requires these indexes
+# 2. Optional - users can add additional indexes here if their specific use case requires them
+#
+# By default GoFHIR automatically creates compound indexes on all reference fields for each resource. These
+# indexes compound the referenceid and type fields. For more information on compound indexes see:
+# https://docs.mongodb.com/manual/core/index-compound/
+#
+# Standard indexes in this file should have the following format:
+# <collection_name>.<key>_(-)1
+# 
+# Where the sort order can be specified as 1 (ascending) or -1 (descending).
+# 
+# Compound indexes in this file should have the following format:
+# <collection_name>.(<key1>_(-)1, <key2>_(-)1, ...)
+
+# -------------------------------------------------------------------------------------------------
+# Collection: accounts
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+accounts.(owner.referenceid_1, owner.type_1)
+accounts.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: allergyintolerances
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+allergyintolerances.(patient.referenceid_1, patient.type_1)
+allergyintolerances.(recorder.referenceid_1, recorder.type_1)
+allergyintolerances.(reporter.referenceid_1, reporter.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: appointmentresponses
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+appointmentresponses.(actor.referenceid_1, actor.type_1)
+appointmentresponses.(appointment.referenceid_1, appointment.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: appointments
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+appointments.(participant.actor.referenceid_1, participant.actor.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: auditevents
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+auditevents.(object.reference.referenceid_1, object.reference.type_1)
+auditevents.(participant.reference.referenceid_1, participant.reference.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: basics
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+basics.(author.referenceid_1, author.type_1)
+basics.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: binaries
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+# No required indexes for this resource
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: bodysites
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+bodysites.(patient.referenceid_1, patient.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: bundles
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+bundles.(entry.resource.referenceid_1, entry.resource.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: careplans
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+careplans.(activity.detail.performer.referenceid_1, activity.detail.performer.type_1)
+careplans.(activity.reference.referenceid_1, activity.reference.type_1)
+careplans.(addresses.referenceid_1, addresses.type_1)
+careplans.(goal.referenceid_1, goal.type_1)
+careplans.(participant.member.referenceid_1, participant.member.type_1)
+careplans.(relatedPlan.plan.referenceid_1, relatedPlan.plan.type_1)
+careplans.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: claimresponses
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+# No required indexes for this resource
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: claims
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+claims.(patient.referenceid_1, patient.type_1)
+claims.(provider.referenceid_1, provider.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: clinicalimpressions
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+clinicalimpressions.(action.referenceid_1, action.type_1)
+clinicalimpressions.(assessor.referenceid_1, assessor.type_1)
+clinicalimpressions.(investigations.item.referenceid_1, investigations.item.type_1)
+clinicalimpressions.(patient.referenceid_1, patient.type_1)
+clinicalimpressions.(plan.referenceid_1, plan.type_1)
+clinicalimpressions.(previous.referenceid_1, previous.type_1)
+clinicalimpressions.(problem.referenceid_1, problem.type_1)
+clinicalimpressions.(triggerReference.referenceid_1, triggerReference.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: communicationrequests
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+communicationrequests.(encounter.referenceid_1, encounter.type_1)
+communicationrequests.(recipient.referenceid_1, recipient.type_1)
+communicationrequests.(requester.referenceid_1, requester.type_1)
+communicationrequests.(sender.referenceid_1, sender.type_1)
+communicationrequests.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: communications
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+communications.(encounter.referenceid_1, encounter.type_1)
+communications.(recipient.referenceid_1, recipient.type_1)
+communications.(requestDetail.referenceid_1, requestDetail.type_1)
+communications.(sender.referenceid_1, sender.type_1)
+communications.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: compositions
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+compositions.(attester.party.referenceid_1, attester.party.type_1)
+compositions.(author.referenceid_1, author.type_1)
+compositions.(encounter.referenceid_1, encounter.type_1)
+compositions.(section.entry.referenceid_1, section.entry.type_1)
+compositions.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: conceptmaps
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+conceptmaps.(sourceReference.referenceid_1, sourceReference.type_1)
+conceptmaps.(targetReference.referenceid_1, targetReference.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: conditions
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+conditions.(asserter.referenceid_1, asserter.type_1)
+conditions.(encounter.referenceid_1, encounter.type_1)
+conditions.(patient.referenceid_1, patient.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: conformances
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+conformances.(profile.referenceid_1, profile.type_1)
+conformances.(rest.resource.profile.referenceid_1, rest.resource.profile.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: contracts
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+contracts.(actor.entity.referenceid_1, actor.entity.type_1)
+contracts.(signer.party.referenceid_1, signer.party.type_1)
+contracts.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: coverages
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+coverages.(issuer.referenceid_1, issuer.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: dataelements
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+# No required indexes for this resource
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: detectedissues
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+detectedissues.(author.referenceid_1, author.type_1)
+detectedissues.(implicated.referenceid_1, implicated.type_1)
+detectedissues.(patient.referenceid_1, patient.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: devicecomponents
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+devicecomponents.(parent.referenceid_1, parent.type_1)
+devicecomponents.(source.referenceid_1, source.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: devicemetrics
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+devicemetrics.(parent.referenceid_1, parent.type_1)
+devicemetrics.(source.referenceid_1, source.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: devices
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+devices.(location.referenceid_1, location.type_1)
+devices.(owner.referenceid_1, owner.type_1)
+devices.(patient.referenceid_1, patient.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: deviceuserequests
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+deviceuserequests.(device.referenceid_1, device.type_1)
+deviceuserequests.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: deviceusestatements
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+deviceusestatements.(device.referenceid_1, device.type_1)
+deviceusestatements.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: diagnosticorders
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+diagnosticorders.(encounter.referenceid_1, encounter.type_1)
+diagnosticorders.(event.actor.referenceid_1, event.actor.type_1)
+diagnosticorders.(item.specimen.referenceid_1, item.specimen.type_1)
+diagnosticorders.(orderer.referenceid_1, orderer.type_1)
+diagnosticorders.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: diagnosticreports
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+diagnosticreports.(encounter.referenceid_1, encounter.type_1)
+diagnosticreports.(image.link.referenceid_1, image.link.type_1)
+diagnosticreports.(performer.referenceid_1, performer.type_1)
+diagnosticreports.(request.referenceid_1, request.type_1)
+diagnosticreports.(result.referenceid_1, result.type_1)
+diagnosticreports.(specimen.referenceid_1, specimen.type_1)
+diagnosticreports.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: documentmanifests
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+documentmanifests.(author.referenceid_1, author.type_1)
+documentmanifests.(content.pReference.referenceid_1, content.pReference.type_1)
+documentmanifests.(recipient.referenceid_1, recipient.type_1)
+documentmanifests.(related.ref.referenceid_1, related.ref.type_1)
+documentmanifests.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: documentreferences
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+documentreferences.(authenticator.referenceid_1, authenticator.type_1)
+documentreferences.(author.referenceid_1, author.type_1)
+documentreferences.(context.encounter.referenceid_1, context.encounter.type_1)
+documentreferences.(context.related.ref.referenceid_1, context.related.ref.type_1)
+documentreferences.(custodian.referenceid_1, custodian.type_1)
+documentreferences.(relatesTo.target.referenceid_1, relatesTo.target.type_1)
+documentreferences.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: eligibilityrequests
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+# No required indexes for this resource
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: eligibilityresponses
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+# No required indexes for this resource
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: encounters
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+encounters.(appointment.referenceid_1, appointment.type_1)
+encounters.(episodeOfCare.referenceid_1, episodeOfCare.type_1)
+encounters.(incomingReferral.referenceid_1, incomingReferral.type_1)
+encounters.(indication.referenceid_1, indication.type_1)
+encounters.(location.location.referenceid_1, location.location.type_1)
+encounters.(partOf.referenceid_1, partOf.type_1)
+encounters.(participant.individual.referenceid_1, participant.individual.type_1)
+encounters.(patient.referenceid_1, patient.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: enrollmentrequests
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+enrollmentrequests.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: enrollmentresponses
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+# No required indexes for this resource
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: episodeofcares
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+episodeofcares.(careManager.referenceid_1, careManager.type_1)
+episodeofcares.(careTeam.member.referenceid_1, careTeam.member.type_1)
+episodeofcares.(condition.referenceid_1, condition.type_1)
+episodeofcares.(managingOrganization.referenceid_1, managingOrganization.type_1)
+episodeofcares.(patient.referenceid_1, patient.type_1)
+episodeofcares.(referralRequest.referenceid_1, referralRequest.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: explanationofbenefits
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+# No required indexes for this resource
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: familymemberhistories
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+familymemberhistories.(patient.referenceid_1, patient.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: flags
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+flags.(author.referenceid_1, author.type_1)
+flags.(encounter.referenceid_1, encounter.type_1)
+flags.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: goals
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+goals.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: groups
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+groups.(member.entity.referenceid_1, member.entity.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: healthcareservices
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+healthcareservices.(location.referenceid_1, location.type_1)
+healthcareservices.(providedBy.referenceid_1, providedBy.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: imagingobjectselections
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+imagingobjectselections.(author.referenceid_1, author.type_1)
+imagingobjectselections.(patient.referenceid_1, patient.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: imagingstudies
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+imagingstudies.(order.referenceid_1, order.type_1)
+imagingstudies.(patient.referenceid_1, patient.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: immunizationrecommendations
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+immunizationrecommendations.(patient.referenceid_1, patient.type_1)
+immunizationrecommendations.(recommendation.supportingImmunization.referenceid_1, recommendation.supportingImmunization.type_1)
+immunizationrecommendations.(recommendation.supportingPatientInformation.referenceid_1, recommendation.supportingPatientInformation.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: immunizations
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+immunizations.(location.referenceid_1, location.type_1)
+immunizations.(manufacturer.referenceid_1, manufacturer.type_1)
+immunizations.(patient.referenceid_1, patient.type_1)
+immunizations.(performer.referenceid_1, performer.type_1)
+immunizations.(reaction.detail.referenceid_1, reaction.detail.type_1)
+immunizations.(requester.referenceid_1, requester.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: implementationguides
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+# No required indexes for this resource
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: lists
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+lists.(encounter.referenceid_1, encounter.type_1)
+lists.(entry.item.referenceid_1, entry.item.type_1)
+lists.(source.referenceid_1, source.type_1)
+lists.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: locations
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+locations.(managingOrganization.referenceid_1, managingOrganization.type_1)
+locations.(partOf.referenceid_1, partOf.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: media
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+media.(operator.referenceid_1, operator.type_1)
+media.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: medicationadministrations
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+medicationadministrations.(device.referenceid_1, device.type_1)
+medicationadministrations.(encounter.referenceid_1, encounter.type_1)
+medicationadministrations.(medicationReference.referenceid_1, medicationReference.type_1)
+medicationadministrations.(patient.referenceid_1, patient.type_1)
+medicationadministrations.(practitioner.referenceid_1, practitioner.type_1)
+medicationadministrations.(prescription.referenceid_1, prescription.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: medicationdispenses
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+medicationdispenses.(authorizingPrescription.referenceid_1, authorizingPrescription.type_1)
+medicationdispenses.(destination.referenceid_1, destination.type_1)
+medicationdispenses.(dispenser.referenceid_1, dispenser.type_1)
+medicationdispenses.(medicationReference.referenceid_1, medicationReference.type_1)
+medicationdispenses.(patient.referenceid_1, patient.type_1)
+medicationdispenses.(receiver.referenceid_1, receiver.type_1)
+medicationdispenses.(substitution.responsibleParty.referenceid_1, substitution.responsibleParty.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: medicationorders
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+medicationorders.(encounter.referenceid_1, encounter.type_1)
+medicationorders.(medicationReference.referenceid_1, medicationReference.type_1)
+medicationorders.(patient.referenceid_1, patient.type_1)
+medicationorders.(prescriber.referenceid_1, prescriber.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: medications
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+medications.(manufacturer.referenceid_1, manufacturer.type_1)
+medications.(package.content.item.referenceid_1, package.content.item.type_1)
+medications.(product.ingredient.item.referenceid_1, product.ingredient.item.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: medicationstatements
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+medicationstatements.(informationSource.referenceid_1, informationSource.type_1)
+medicationstatements.(medicationReference.referenceid_1, medicationReference.type_1)
+medicationstatements.(patient.referenceid_1, patient.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: messageheaders
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+messageheaders.(author.referenceid_1, author.type_1)
+messageheaders.(data.referenceid_1, data.type_1)
+messageheaders.(destination.target.referenceid_1, destination.target.type_1)
+messageheaders.(enterer.referenceid_1, enterer.type_1)
+messageheaders.(receiver.referenceid_1, receiver.type_1)
+messageheaders.(responsible.referenceid_1, responsible.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: namingsystems
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+namingsystems.(replacedBy.referenceid_1, replacedBy.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: nutritionorders
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+nutritionorders.(encounter.referenceid_1, encounter.type_1)
+nutritionorders.(orderer.referenceid_1, orderer.type_1)
+nutritionorders.(patient.referenceid_1, patient.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: observations
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+observations.(device.referenceid_1, device.type_1)
+observations.(encounter.referenceid_1, encounter.type_1)
+observations.(performer.referenceid_1, performer.type_1)
+observations.(related.target.referenceid_1, related.target.type_1)
+observations.(specimen.referenceid_1, specimen.type_1)
+observations.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: operationdefinitions
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+operationdefinitions.(base.referenceid_1, base.type_1)
+operationdefinitions.(parameter.profile.referenceid_1, parameter.profile.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: operationoutcomes
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+# No required indexes for this resource
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: orderresponses
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+orderresponses.(fulfillment.referenceid_1, fulfillment.type_1)
+orderresponses.(request.referenceid_1, request.type_1)
+orderresponses.(who.referenceid_1, who.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: orders
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+orders.(detail.referenceid_1, detail.type_1)
+orders.(source.referenceid_1, source.type_1)
+orders.(subject.referenceid_1, subject.type_1)
+orders.(target.referenceid_1, target.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: organizations
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+organizations.(partOf.referenceid_1, partOf.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: patients
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+patients.(careProvider.referenceid_1, careProvider.type_1)
+patients.(link.other.referenceid_1, link.other.type_1)
+patients.(managingOrganization.referenceid_1, managingOrganization.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: paymentnotices
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+# No required indexes for this resource
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: paymentreconciliations
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+# No required indexes for this resource
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: people
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+people.(link.target.referenceid_1, link.target.type_1)
+people.(managingOrganization.referenceid_1, managingOrganization.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: practitioners
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+practitioners.(practitionerRole.location.referenceid_1, practitionerRole.location.type_1)
+practitioners.(practitionerRole.managingOrganization.referenceid_1, practitionerRole.managingOrganization.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: procedurerequests
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+procedurerequests.(encounter.referenceid_1, encounter.type_1)
+procedurerequests.(orderer.referenceid_1, orderer.type_1)
+procedurerequests.(performer.referenceid_1, performer.type_1)
+procedurerequests.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: procedures
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+procedures.(encounter.referenceid_1, encounter.type_1)
+procedures.(location.referenceid_1, location.type_1)
+procedures.(performer.actor.referenceid_1, performer.actor.type_1)
+procedures.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: processrequests
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+processrequests.(organization.referenceid_1, organization.type_1)
+processrequests.(provider.referenceid_1, provider.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: processresponses
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+processresponses.(organization.referenceid_1, organization.type_1)
+processresponses.(request.referenceid_1, request.type_1)
+processresponses.(requestOrganization.referenceid_1, requestOrganization.type_1)
+processresponses.(requestProvider.referenceid_1, requestProvider.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: provenances
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+provenances.(agent.actor.referenceid_1, agent.actor.type_1)
+provenances.(location.referenceid_1, location.type_1)
+provenances.(target.referenceid_1, target.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: questionnaireresponses
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+questionnaireresponses.(author.referenceid_1, author.type_1)
+questionnaireresponses.(encounter.referenceid_1, encounter.type_1)
+questionnaireresponses.(questionnaire.referenceid_1, questionnaire.type_1)
+questionnaireresponses.(source.referenceid_1, source.type_1)
+questionnaireresponses.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: questionnaires
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+# No required indexes for this resource
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: referralrequests
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+referralrequests.(patient.referenceid_1, patient.type_1)
+referralrequests.(recipient.referenceid_1, recipient.type_1)
+referralrequests.(requester.referenceid_1, requester.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: relatedpeople
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+relatedpeople.(patient.referenceid_1, patient.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: riskassessments
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+riskassessments.(condition.referenceid_1, condition.type_1)
+riskassessments.(encounter.referenceid_1, encounter.type_1)
+riskassessments.(performer.referenceid_1, performer.type_1)
+riskassessments.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: schedules
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+schedules.(actor.referenceid_1, actor.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: searchparameters
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+# No required indexes for this resource
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: slots
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+slots.(schedule.referenceid_1, schedule.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: specimen
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+specimen.(collection.collector.referenceid_1, collection.collector.type_1)
+specimen.(parent.referenceid_1, parent.type_1)
+specimen.(subject.referenceid_1, subject.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: structuredefinitions
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+structuredefinitions.(snapshot.element.binding.valueSetReference.referenceid_1, snapshot.element.binding.valueSetReference.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: subscriptions
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+# No required indexes for this resource
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: substances
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+substances.(ingredient.substance.referenceid_1, ingredient.substance.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: supplydeliveries
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+supplydeliveries.(patient.referenceid_1, patient.type_1)
+supplydeliveries.(receiver.referenceid_1, receiver.type_1)
+supplydeliveries.(supplier.referenceid_1, supplier.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: supplyrequests
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+supplyrequests.(patient.referenceid_1, patient.type_1)
+supplyrequests.(source.referenceid_1, source.type_1)
+supplyrequests.(supplier.referenceid_1, supplier.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: testscripts
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+# No required indexes for this resource
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: valuesets
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+# No required indexes for this resource
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+
+# -------------------------------------------------------------------------------------------------
+# Collection: visionprescriptions
+# -------------------------------------------------------------------------------------------------
+# Required Indexes:
+visionprescriptions.(encounter.referenceid_1, encounter.type_1)
+visionprescriptions.(patient.referenceid_1, patient.type_1)
+visionprescriptions.(prescriber.referenceid_1, prescriber.type_1)
+
+# Optional Indexes:
+# You can add additional indexes here if needed
+

--- a/server.go
+++ b/server.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 
-	"github.com/intervention-engine/fhir/auth"
 	"github.com/intervention-engine/fhir/server"
 )
 
@@ -15,5 +14,5 @@ func main() {
 		s.Engine.Use(server.RequestLoggerHandler)
 	}
 
-	s.Run(server.Config{Auth: auth.None(), ServerURL: "http://localhost:3001"})
+	s.Run(server.DefaultConfig)
 }


### PR DESCRIPTION
This PR takes advantage of recent updates to the fhir server library to support configurable indexes.  It provides the default index configuration file, which indexes all fields that correspond to reference search parameters (i.e., similar to indexes foreign key fields in a relational database).

In addition, the README was fixed to include a missing `go get` command.
